### PR TITLE
Set KERNEL_OUTPUT_DIR variable

### DIFF
--- a/conf/machine/include/miraclebox.inc
+++ b/conf/machine/include/miraclebox.inc
@@ -35,6 +35,7 @@ PREFERRED_PROVIDER_virtual/blindscan-dvbs = "miraclebox-blindscan-utils-${MACHIN
 
 KERNEL_IMAGETYPE = "vmlinux"
 KERNEL_OUTPUT = "${KERNEL_IMAGETYPE}"
+KERNEL_OUTPUT_DIR = "."
 KERNEL_CONSOLE = "null"
 SERIAL_CONSOLE ?= ""
 


### PR DESCRIPTION
KERNEL_OUTPUT_DIR defaults to arch/${ARCH}/boot, which isn't where
these kernels end up. Previously this was done with KERNEL_OUTPUT,
but now that the kernel class supports multiple recipes, setting
KERNEL_OUTPUT_DIR to "./" fixes the kernel recipes no longer
building.

Signed-off-by: Erik Slagter erik@openpli.org
